### PR TITLE
Add support for classPrefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 node_modules/
 npm-debug.log
 
+# IDE
+.idea
+*.iml

--- a/README.md
+++ b/README.md
@@ -35,6 +35,34 @@ Removes `width` and `height` attributes from `<svg />`.
 
 default: `removeSVGTagAttrs: true`
 
+#### `classPrefix: boolean || string`
+
+Adds a prefix to class names to avoid collision across svg files.
+
+default: `classPrefix: false`
+
+##### Example Usage
+```js
+// Using default hashed prefix (__[hash:base64:7]__)
+var logoTwo = require('svg-inline?classPrefix!./logo_two.svg');
+
+// Using custom string
+var logoOne = require('svg-inline?classPrefix=my-prefix-!./logo_one.svg');
+
+// Using custom string and hash
+var logoThree = require('svg-inline?classPrefix=__prefix-[sha512:hash:hex:5]__!./logo_three.svg');
+```
+See [loader-utils](https://github.com/webpack/loader-utils#interpolatename) for hash options.
+
+Preferred usage is via a `module.loaders`:
+```js
+    {
+        test: /\.svg$/,
+        loader: 'svg-inline?classPrefix'
+    }
+```
+
+
 ## Notes
 
 - `<IconSVG />` React Component is **DEPRECATED**, use `svg-inline-react` package instead.

--- a/config.js
+++ b/config.js
@@ -6,5 +6,6 @@ module.exports = {
         'desc',
         'defs',
         'style'
-    ]
+    ],
+    classPrefix: false
 };

--- a/index.js
+++ b/index.js
@@ -20,6 +20,10 @@ var regexSequences = [
 ];
 
 function getExtractedSVG(svgStr, query) {
+    // interpolate hashes in classPrefix
+    if(!!query && 'classPrefix' in query) {
+        query.classPrefix = loaderUtils.interpolateName({}, query.classPrefix, {content: svgStr});
+    }
     // Clean-up XML crusts like comments and doctype, etc.
     var tokens;
     var cleanedUp = regexSequences.reduce(function (prev, regexSequence) {

--- a/index.js
+++ b/index.js
@@ -21,8 +21,9 @@ var regexSequences = [
 
 function getExtractedSVG(svgStr, query) {
     // interpolate hashes in classPrefix
-    if(!!query && 'classPrefix' in query) {
-        query.classPrefix = loaderUtils.interpolateName({}, query.classPrefix, {content: svgStr});
+    if(!!query && !!query.classPrefix) {
+        const name = query.classPrefix === true ? '__[hash:base64:7]__' : query.classPrefix;
+        query.classPrefix = loaderUtils.interpolateName({}, name, {content: svgStr});
     }
     // Clean-up XML crusts like comments and doctype, etc.
     var tokens;

--- a/lib/conditions.js
+++ b/lib/conditions.js
@@ -2,6 +2,10 @@ function isSVGToken (tag) {
     return tag.type === 'StartTag' && tag.tagName === 'svg';
 }
 
+function isStyleToken (tag) {
+    return tag.type === 'StartTag' && tag.tagName === 'style';
+}
+
 function isFilledObject (obj) {
     return obj != null &&
            typeof obj === 'object' &&
@@ -14,6 +18,7 @@ function hasNoWidthHeight(attributeToken) {
 
 module.exports = {
     isSVGToken: isSVGToken,
+    isStyleToken: isStyleToken,
     isFilledObject: isFilledObject,
     hasNoWidthHeight: hasNoWidthHeight
 };

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -87,7 +87,7 @@ function runTransform(tokens, configOverride) {
 
     if (config.removeSVGTagAttrs === true) transformations.push(removeSVGTagAttrs);
     if (config.removeTags        === true) transformations.push(createRemoveTags(config.removingTags));
-    if ('classPrefix' in config          ) transformations.push(createClassPrefix(config.classPrefix));
+    if (config.classPrefix      !== false) transformations.push(createClassPrefix(config.classPrefix));
 
     transformations.forEach(function (transformation) {
         tokens = tokens.map(transformation);

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -36,6 +36,50 @@ function createRemoveTags(removingTags) {
     }
 }
 
+function getAttributeIndex (tag, attr) {
+    if( tag.attributes !== undefined && tag.attributes.length > 0 ) {
+        for(var i = 0; i < tag.attributes.length; i++) {
+            if(tag.attributes[i][0] === attr) {
+                return i;
+            }
+        }
+    }
+    return -1;
+}
+
+function createClassPrefix(classPrefix) {
+    var re = /\.[\w\-]+/g;
+    var inStyleTag = false;
+
+    return function prefixClasses(tag) {
+        if( inStyleTag ) {
+            var string = tag.chars;
+            // push matches to an array so we can operate in reverse
+            var match;
+            var matches = [];
+            while(match = re.exec(string)) matches.push(match);
+            // update the string in reverse so our matches indices don't get off
+            for(var i = matches.length-1; i>=0; i--) {
+                string = string.substring(0,matches[i].index+1) +
+                    classPrefix +
+                    string.substring(matches[i].index+1);
+            }
+            tag.chars = string;
+            inStyleTag = false;
+        }
+        else if (conditions.isStyleToken(tag)) {
+            inStyleTag = true;
+        }
+        else {
+            var classIdx = getAttributeIndex(tag,'class');
+            if(classIdx >= 0) {
+                tag.attributes[classIdx][1] = classPrefix + tag.attributes[classIdx][1];
+            }
+        }
+        return tag;
+    }
+}
+
 function runTransform(tokens, configOverride) {
     var transformations = [];
     var config = conditions.isFilledObject(configOverride) ? assign({}, defaultConfig, configOverride) :
@@ -43,6 +87,7 @@ function runTransform(tokens, configOverride) {
 
     if (config.removeSVGTagAttrs === true) transformations.push(removeSVGTagAttrs);
     if (config.removeTags        === true) transformations.push(createRemoveTags(config.removingTags));
+    if ('classPrefix' in config          ) transformations.push(createClassPrefix(config.classPrefix));
 
     transformations.forEach(function (transformation) {
         tokens = tokens.map(transformation);
@@ -54,5 +99,6 @@ function runTransform(tokens, configOverride) {
 module.exports = {
     removeSVGTagAttrs: removeSVGTagAttrs,
     createRemoveTags: createRemoveTags,
+    createClassPrefix: createClassPrefix,
     runTransform: runTransform
 };

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -85,9 +85,9 @@ function runTransform(tokens, configOverride) {
     var config = conditions.isFilledObject(configOverride) ? assign({}, defaultConfig, configOverride) :
                                                              defaultConfig;
 
+    if (config.classPrefix      !== false) transformations.push(createClassPrefix(config.classPrefix));
     if (config.removeSVGTagAttrs === true) transformations.push(removeSVGTagAttrs);
     if (config.removeTags        === true) transformations.push(createRemoveTags(config.removingTags));
-    if (config.classPrefix      !== false) transformations.push(createClassPrefix(config.classPrefix));
 
     transformations.forEach(function (transformation) {
         tokens = tokens.map(transformation);

--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
     "karma-spec-reporter": "0.0.19",
     "karma-webpack": "^1.5.1",
     "lodash": "^4.6.1",
+    "mocha": "^2.5.3",
     "node-libs-browser": "^0.5.2",
-    "raw-loader": "^0.5.1"
+    "raw-loader": "^0.5.1",
+    "webpack": "^1.13.1"
   }
 }

--- a/tests/fixtures/style-inserted.svg
+++ b/tests/fixtures/style-inserted.svg
@@ -2,10 +2,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" preserveAspectRatio="xMidYMid" width="48" height="48" viewBox="0 0 48 48">
   <defs>
     <style>
-      .cls-1 {
+      .cls-1,.cls_2 {
         fill: #000;
         fill-rule: evenodd;
       }
+      .c,.f,.g,
+      .h,.l{fill:none;stroke-miterlimit:10;}.c,.f,.g{stroke:#ccc;}
     </style>
   </defs>
   <g id="artboard-1">

--- a/tests/svg-inline-loader.test.js
+++ b/tests/svg-inline-loader.test.js
@@ -38,6 +38,16 @@ describe('getExtractedSVG()', function(){
         });
     });
 
+    it('should apply prefixes to class names', function () {
+        var svgWithStyle = require('raw!./fixtures/style-inserted.svg');
+        var processedStyleInsertedSVG = SVGInlineLoader.getExtractedSVG(svgWithStyle, { classPrefix: 'test.prefix-' });
+
+        // Are all 10 classes prefixed in <style>
+        assert.isTrue( processedStyleInsertedSVG.match(/\.test\.prefix-/g).length === 10 );
+        // Is class attribute prefixed
+        assert.isTrue( processedStyleInsertedSVG.match(/class="test\.prefix-/g).length === 1 );
+    });
+
     it('should be able to specify tags to be removed by `removingTags` option', function () {
         var svgRemovingTags = require('raw!./fixtures/removing-tags.svg');
         var tobeRemoved = require('raw!./fixtures/removing-tags-to-be-removed.json');


### PR DESCRIPTION
This address the issues outlined in #28 by providing the ability to prefix class names to avoid name collision with inline svgs.