### PR TITLE
Fixed a bug where removingTagAttrs didn't return end tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.1
+
+* Fixed a bug when using `removingTagAttrs`
+
 ## 0.6.0
 
 * Added `classPrefix` option (by @kinetifex)

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -16,8 +16,8 @@ function createRemoveTagAttrs(removingTagAttrs) {
     return function removeTagAttrs(tag) {
         if (conditions.isStartTag(tag)) {
             tag.attributes = tag.attributes.filter(hasNoAttributes);
-            return tag;
         }
+        return tag;
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svg-inline-loader",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Cleans up and inlines your SVG files into Webpack module.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I made a mistake when implementing `removingTagAttrs` and only returned the tag if it was a startTag. Oops!