### PR TITLE
multiple classes in class string, fix issue #39

### DIFF
--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -83,7 +83,17 @@ function createClassPrefix(classPrefix) {
         else {
             var classIdx = getAttributeIndex(tag,'class');
             if(classIdx >= 0) {
-                tag.attributes[classIdx][1] = classPrefix + tag.attributes[classIdx][1];
+                //Prefix classes when multiple classes are present
+                var classes = tag.attributes[classIdx][1];
+                var prefixedClassString = "";
+                
+                classes = classes.replace(/[ ]+/,' ');
+                classes = classes.split(' ');
+                classes.forEach(function(classI){
+                    prefixedClassString += classPrefix + classI + ' ';
+                });
+                
+                tag.attributes[classIdx][1] = prefixedClassString;
             }
         }
         return tag;


### PR DESCRIPTION
Multiple classses in class attribute not prefixed when using classPrefix

[Issue 39](https://github.com/sairion/svg-inline-loader/issues/39)
